### PR TITLE
Press-to-bind hotkeys in settings

### DIFF
--- a/src/lib/components/hotkeys/Hotkeys.svelte
+++ b/src/lib/components/hotkeys/Hotkeys.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { shortcut } from "$lib/components/hotkeys/shortcut.js";
+  import { shortcut, display } from "$lib/components/hotkeys/shortcut.js";
   import { hotkeys } from "$lib/stores/hotkeysStore.js";
   let {
     replaceBody,
@@ -30,12 +30,7 @@
         >
           <div class="flex flex-col">
             <div class="lg:text-lg">{markerColors[i].text}</div>
-            <div class="text-xs">
-              {hotkey.modifiers.control ? "CTL + " : ""}
-              {hotkey.modifiers.shift ? "SHIFT + " : ""}
-              {hotkey.modifiers.alt ? "ALT + " : ""}
-              {hotkey.key}
-            </div>
+            <div class="text-xs">{display(hotkey)}</div>
           </div>
         </button>
       {/if}

--- a/src/lib/components/hotkeys/PersonalHotkeys.svelte
+++ b/src/lib/components/hotkeys/PersonalHotkeys.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { shortcut } from "$lib/components/hotkeys/shortcut.js";
+  import { shortcut, display } from "$lib/components/hotkeys/shortcut.js";
   import { personalHotkeys } from "$lib/stores/hotkeysStore.js";
   let { replaceBody, inTimecode, setTimecodeToNow } = $props();
 </script>
@@ -25,12 +25,7 @@
         >
           <div class="flex flex-col">
             <div class="lg:text-lg">{hotkey.text}</div>
-            <div class="text-xs">
-              {hotkey.modifiers.control ? "CTL + " : ""}
-              {hotkey.modifiers.shift ? "SHIFT + " : ""}
-              {hotkey.modifiers.alt ? "ALT + " : ""}
-              {hotkey.key}
-            </div>
+            <div class="text-xs">{display(hotkey)}</div>
           </div>
         </button>
       {/if}

--- a/src/lib/components/hotkeys/shortcut.js
+++ b/src/lib/components/hotkeys/shortcut.js
@@ -1,25 +1,21 @@
 export const shortcut = (node, params) => {
-  let handler;
-  const removeHandler = () => window.removeEventListener("keydown", handler),
-    setHandler = () => {
-      removeHandler();
-      if (!params) return;
-      handler = (e) => {
-        if (
-          !!params.alt != e.altKey ||
-          !!params.shift != e.shiftKey ||
-          !!params.control != (e.ctrlKey || e.metaKey) ||
-          params.code != e.key
-        )
-          return;
-        e.preventDefault();
-        params.callback ? params.callback() : node.click();
-      };
-      window.addEventListener("keydown", handler);
-    };
-  setHandler();
+  // params is read at event time, so `update` only has to swap the reference —
+  // no listener churn, and rebound hotkeys take effect immediately.
+  const handler = (e) => {
+    if (!params) return;
+    if (
+      !!params.alt != e.altKey ||
+      !!params.shift != e.shiftKey ||
+      !!params.control != (e.ctrlKey || e.metaKey) ||
+      params.code != e.key
+    )
+      return;
+    e.preventDefault();
+    params.callback ? params.callback() : node.click();
+  };
+  window.addEventListener("keydown", handler);
   return {
-    update: setHandler,
-    destroy: removeHandler,
+    update: (newParams) => (params = newParams),
+    destroy: () => window.removeEventListener("keydown", handler),
   };
 };

--- a/src/lib/components/hotkeys/shortcut.js
+++ b/src/lib/components/hotkeys/shortcut.js
@@ -1,3 +1,26 @@
+// What to store when binding a key. event.key is the *typed* character, so
+// Shift+1 reads "!" and macOS Alt+R reads "®" — bind the physical key instead
+// and the label stays "1" / "R" whatever the modifiers do to it.
+export const keyFromEvent = (e) =>
+  /^(Key|Digit)./.test(e.code)
+    ? e.code.replace(/^(Key|Digit)/, "").toLowerCase()
+    : e.key;
+
+// Label for a stored binding, e.g. "ALT + R". Physical keys are stored
+// lowercase, so single characters are uppercased for display.
+export const display = (h) =>
+  (h.modifiers.control ? "CTL + " : "") +
+  (h.modifiers.shift ? "SHIFT + " : "") +
+  (h.modifiers.alt ? "ALT + " : "") +
+  (h.key === " " ? "Space" : h.key.toUpperCase());
+
+// Bindings are stored as the physical key, but event.key still carries the
+// typed character, so single-character bindings match on either.
+const matchesKey = (e, code) =>
+  code == e.key ||
+  (code?.length === 1 &&
+    (e.code === `Key${code.toUpperCase()}` || e.code === `Digit${code}`));
+
 export const shortcut = (node, params) => {
   // params is read at event time, so `update` only has to swap the reference —
   // no listener churn, and rebound hotkeys take effect immediately.
@@ -7,7 +30,7 @@ export const shortcut = (node, params) => {
       !!params.alt != e.altKey ||
       !!params.shift != e.shiftKey ||
       !!params.control != (e.ctrlKey || e.metaKey) ||
-      params.code != e.key
+      !matchesKey(e, params.code)
     )
       return;
     e.preventDefault();

--- a/src/lib/components/hotkeys/shortcut.test.js
+++ b/src/lib/components/hotkeys/shortcut.test.js
@@ -1,10 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { shortcut } from "./shortcut.js";
+import { shortcut, keyFromEvent } from "./shortcut.js";
 
 // ponytail: hand-rolled window stub instead of pulling in jsdom for one test
 let listeners;
 const fakeEvent = (key, mods = {}) => ({
   key,
+  code: mods.code,
   altKey: !!mods.alt,
   shiftKey: !!mods.shift,
   ctrlKey: !!mods.control,
@@ -24,6 +25,20 @@ beforeEach(() => {
 
 afterEach(() => {
   delete globalThis.window;
+});
+
+describe("keyFromEvent", () => {
+  it("stores the physical key, not the typed character", () => {
+    expect(keyFromEvent({ key: "!", code: "Digit1" })).toBe("1");
+    expect(keyFromEvent({ key: "®", code: "KeyR" })).toBe("r");
+    expect(keyFromEvent({ key: "R", code: "KeyR" })).toBe("r");
+  });
+
+  it("keeps event.key for everything else", () => {
+    expect(keyFromEvent({ key: "F1", code: "F1" })).toBe("F1");
+    expect(keyFromEvent({ key: "Enter", code: "Enter" })).toBe("Enter");
+    expect(keyFromEvent({ key: " ", code: "Space" })).toBe(" ");
+  });
 });
 
 describe("shortcut", () => {
@@ -61,6 +76,25 @@ describe("shortcut", () => {
     expect(fired).toBe(0);
 
     press("F4", { alt: true });
+    expect(fired).toBe(1);
+  });
+
+  it("matches the physical key when macOS rewrites Alt+letter", () => {
+    let fired = 0;
+    shortcut({}, { code: "r", alt: true, callback: () => fired++ });
+
+    press("®", { alt: true, code: "KeyR" });
+    expect(fired).toBe(1);
+
+    press("®", { alt: true, code: "KeyT" }); // different physical key
+    expect(fired).toBe(1);
+  });
+
+  it("matches a physical-key binding through the typed character", () => {
+    let fired = 0;
+    shortcut({}, { code: "1", shift: true, callback: () => fired++ });
+
+    press("!", { shift: true, code: "Digit1" });
     expect(fired).toBe(1);
   });
 

--- a/src/lib/components/hotkeys/shortcut.test.js
+++ b/src/lib/components/hotkeys/shortcut.test.js
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { shortcut } from "./shortcut.js";
+
+// ponytail: hand-rolled window stub instead of pulling in jsdom for one test
+let listeners;
+const fakeEvent = (key, mods = {}) => ({
+  key,
+  altKey: !!mods.alt,
+  shiftKey: !!mods.shift,
+  ctrlKey: !!mods.control,
+  metaKey: !!mods.meta,
+  preventDefault() {},
+});
+const press = (key, mods) => listeners.forEach((l) => l(fakeEvent(key, mods)));
+
+beforeEach(() => {
+  listeners = [];
+  globalThis.window = {
+    addEventListener: (_, h) => listeners.push(h),
+    removeEventListener: (_, h) =>
+      listeners.splice(listeners.indexOf(h) >>> 0, 1),
+  };
+});
+
+afterEach(() => {
+  delete globalThis.window;
+});
+
+describe("shortcut", () => {
+  it("fires the callback on an exact key + modifier match", () => {
+    let fired = 0;
+    shortcut({}, { code: "F1", shift: true, callback: () => fired++ });
+
+    press("F1", { shift: true });
+    expect(fired).toBe(1);
+
+    press("F1"); // missing shift
+    press("F2", { shift: true }); // wrong key
+    press("F1", { shift: true, alt: true }); // extra modifier
+    expect(fired).toBe(1);
+  });
+
+  it("treats meta as control, so Cmd works on macOS", () => {
+    let fired = 0;
+    shortcut({}, { code: "k", control: true, callback: () => fired++ });
+
+    press("k", { meta: true });
+    expect(fired).toBe(1);
+  });
+
+  it("honours rebinding via update", () => {
+    let fired = 0;
+    const { update } = shortcut(
+      {},
+      { code: "F1", callback: () => fired++ }
+    );
+
+    update({ code: "F4", alt: true, callback: () => fired++ });
+
+    press("F1"); // old binding must be dead
+    expect(fired).toBe(0);
+
+    press("F4", { alt: true });
+    expect(fired).toBe(1);
+  });
+
+  it("clicks the node when no callback is given", () => {
+    let clicks = 0;
+    shortcut({ click: () => clicks++ }, { code: "F1" });
+
+    press("F1");
+    expect(clicks).toBe(1);
+  });
+
+  it("stops listening after destroy", () => {
+    let fired = 0;
+    const { destroy } = shortcut({}, { code: "F1", callback: () => fired++ });
+
+    destroy();
+    press("F1");
+    expect(fired).toBe(0);
+    expect(listeners).toHaveLength(0);
+  });
+});

--- a/src/lib/components/menu/HotkeysSettings.svelte
+++ b/src/lib/components/menu/HotkeysSettings.svelte
@@ -66,32 +66,33 @@
   <tr class={conflicts.has(sig(hotkey)) ? "bg-error/20" : ""}>
     <td>{label}</td>
     <td>
-      <span
-        class="tooltip tooltip-right"
-        data-tip={armed?.id === id
-          ? "Press the key combination you want · Esc to cancel"
-          : conflicts.has(sig(hotkey))
-            ? "Same combination as another hotkey · click to rebind"
-            : "Click, then press the key you want"}
-      >
-        <button
-          class="btn btn-xs w-32 font-mono"
-          class:btn-primary={armed?.id === id}
-          onclick={() => (armed = { id, current: hotkey, set })}
+      <div class="flex items-center gap-2">
+        <span
+          class="tooltip tooltip-right"
+          data-tip={armed?.id === id
+            ? "Press the key combination you want · Esc to cancel"
+            : conflicts.has(sig(hotkey))
+              ? "Same combination as another hotkey · click to rebind"
+              : "Click, then press the key you want"}
         >
-          {armed?.id === id ? "Press key…" : display(hotkey)}
-        </button>
-      </span>
-    </td>
-    <td>
-      {#if withText}
-        <input
-          class="input input-xs w-16"
-          type="text"
-          value={hotkey.text}
-          onchange={(e) => set({ ...hotkey, text: e.currentTarget.value })}
-        />
-      {/if}
+          <button
+            class="btn btn-xs w-32 font-mono"
+            class:btn-primary={armed?.id === id}
+            onclick={() => (armed = { id, current: hotkey, set })}
+          >
+            {armed?.id === id ? "Press key…" : display(hotkey)}
+          </button>
+        </span>
+        {#if withText}
+          <input
+            class="input input-xs flex-1"
+            type="text"
+            placeholder="Input text"
+            value={hotkey.text}
+            onchange={(e) => set({ ...hotkey, text: e.currentTarget.value })}
+          />
+        {/if}
+      </div>
     </td>
   </tr>
 {/snippet}
@@ -102,7 +103,6 @@
       <tr>
         <th>type</th>
         <th>Keybind</th>
-        <th>opt</th>
       </tr>
     </thead>
     <tbody>
@@ -128,7 +128,7 @@
         )}
       {/each}
       <tr
-        ><td colspan="2" class="text-center"
+        ><td class="text-center"
           >Click a key to rebind · Esc cancels · changes apply immediately</td
         >
         <td

--- a/src/lib/components/menu/HotkeysSettings.svelte
+++ b/src/lib/components/menu/HotkeysSettings.svelte
@@ -5,6 +5,7 @@
     resetHotkey,
     timecodeHotkey,
     personalHotkeys,
+    defaults,
   } from "$lib/stores/hotkeysStore.js";
 
   // { id, current, set } of the row waiting for a keypress, or null
@@ -135,54 +136,17 @@
           ><button
             class="btn btn-xs"
             onclick={() => {
-              hotkeys.set([
-                {
-                  key: "F1",
-                  modifiers: { control: false, shift: false, alt: false },
-                },
-                {
-                  key: "F2",
-                  modifiers: { control: false, shift: false, alt: false },
-                },
-                {
-                  key: "F3",
-                  modifiers: { control: false, shift: false, alt: false },
-                },
-                {
-                  key: "F4",
-                  modifiers: { control: false, shift: false, alt: false },
-                },
-                {
-                  key: "F5",
-                  modifiers: { control: false, shift: false, alt: false },
-                },
-                {
-                  key: "F6",
-                  modifiers: { control: false, shift: false, alt: false },
-                },
-                {
-                  key: "F7",
-                  modifiers: { control: false, shift: false, alt: false },
-                },
-                {
-                  key: "F8",
-                  modifiers: { control: false, shift: false, alt: false },
-                },
-              ]);
-              submitHotkey.set({
-                key: "F1",
-                modifiers: { control: false, shift: true, alt: false },
-              });
-
-              resetHotkey.set({
-                key: "F2",
-                modifiers: { control: false, shift: true, alt: false },
-              });
-
-              timecodeHotkey.set({
-                key: "F3",
-                modifiers: { control: false, shift: true, alt: false },
-              });
+              hotkeys.set(structuredClone(defaults.hotkeys));
+              submitHotkey.set(structuredClone(defaults.submitHotkey));
+              resetHotkey.set(structuredClone(defaults.resetHotkey));
+              timecodeHotkey.set(structuredClone(defaults.timecodeHotkey));
+              // keybinds go back to default, the user's typed text stays
+              personalHotkeys.update((current) =>
+                defaults.personalHotkeys.map((d, i) => ({
+                  ...structuredClone(d),
+                  text: current[i]?.text ?? "",
+                }))
+              );
             }}>Reset hotkeys</button
           ></td
         >

--- a/src/lib/components/menu/HotkeysSettings.svelte
+++ b/src/lib/components/menu/HotkeysSettings.svelte
@@ -6,7 +6,108 @@
     timecodeHotkey,
     personalHotkeys,
   } from "$lib/stores/hotkeysStore.js";
+
+  // { id, current, set } of the row waiting for a keypress, or null
+  let armed = $state(null);
+
+  const MODIFIER_KEYS = ["Shift", "Control", "Alt", "Meta"];
+
+  const sig = (h) =>
+    `${h.modifiers.control}${h.modifiers.shift}${h.modifiers.alt}:${h.key}`;
+
+  const display = (h) =>
+    (h.modifiers.control ? "CTL + " : "") +
+    (h.modifiers.shift ? "SHIFT + " : "") +
+    (h.modifiers.alt ? "ALT + " : "") +
+    h.key;
+
+  let allRows = $derived([
+    $submitHotkey,
+    $resetHotkey,
+    $timecodeHotkey,
+    ...$hotkeys,
+    ...$personalHotkeys,
+  ]);
+
+  let conflicts = $derived(
+    new Set(allRows.map(sig).filter((s, i, a) => a.indexOf(s) !== i))
+  );
+
+  $effect(() => {
+    if (!armed) return;
+    const onKey = (e) => {
+      e.preventDefault();
+      // capture phase + stopPropagation so the shortcut action on window
+      // doesn't fire the app's own hotkeys while we're binding
+      e.stopPropagation();
+      if (e.key === "Escape") {
+        armed = null;
+        return;
+      }
+      // ignore modifier-only presses so the user can hold them first
+      if (MODIFIER_KEYS.includes(e.key)) return;
+      armed.set({
+        ...armed.current,
+        key: e.key,
+        modifiers: {
+          control: e.ctrlKey || e.metaKey,
+          shift: e.shiftKey,
+          alt: e.altKey,
+        },
+      });
+      armed = null;
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  });
 </script>
+
+{#snippet row(id, label, hotkey, set, withText = false)}
+  <tr
+    class={conflicts.has(sig(hotkey)) ? "bg-error/20" : ""}
+    title={conflicts.has(sig(hotkey))
+      ? "Same combination as another hotkey"
+      : ""}
+  >
+    <td>{label}</td>
+    <td>
+      <button
+        class="btn btn-xs w-32 font-mono"
+        class:btn-primary={armed?.id === id}
+        onclick={() => (armed = { id, current: hotkey, set })}
+      >
+        {armed?.id === id ? "Press key…" : display(hotkey)}
+      </button>
+    </td>
+    <td>
+      {#if withText}
+        <input
+          class="input input-xs w-16"
+          type="text"
+          value={hotkey.text}
+          onchange={(e) => set({ ...hotkey, text: e.currentTarget.value })}
+        />
+      {/if}
+    </td>
+    {#each ["control", "shift", "alt"] as modifier}
+      <td>
+        <input
+          class="toggle toggle-xs"
+          type="checkbox"
+          checked={hotkey.modifiers[modifier]}
+          onchange={(e) =>
+            set({
+              ...hotkey,
+              modifiers: {
+                ...hotkey.modifiers,
+                [modifier]: e.currentTarget.checked,
+              },
+            })}
+        />
+      </td>
+    {/each}
+  </tr>
+{/snippet}
 
 <div class="flex flex-col gap-1">
   <table class="table table-xs table-zebra w-full">
@@ -21,180 +122,31 @@
       </tr>
     </thead>
     <tbody>
-      <tr>
-        <td>Submit</td>
-        <td>
-          <input
-            class="input input-xs w-16"
-            type="text"
-            bind:value={$submitHotkey.key}
-          />
-        </td>
-        <td></td>
-        <td
-          ><input
-            class="toggle toggle-xs"
-            type="checkbox"
-            bind:checked={$submitHotkey.modifiers.control}
-          /></td
-        >
-        <td
-          ><input
-            class="toggle toggle-xs"
-            type="checkbox"
-            bind:checked={$submitHotkey.modifiers.shift}
-          /></td
-        >
-        <td
-          ><input
-            class="toggle toggle-xs"
-            type="checkbox"
-            bind:checked={$submitHotkey.modifiers.alt}
-          /></td
-        >
-      </tr>
-      <tr>
-        <td>Reset</td>
-        <td>
-          <input
-            class="input input-xs w-16"
-            type="text"
-            bind:value={$resetHotkey.key}
-          />
-        </td>
-        <td></td>
-        <td
-          ><input
-            class="toggle toggle-xs"
-            type="checkbox"
-            bind:checked={$resetHotkey.modifiers.control}
-          /></td
-        >
-
-        <td
-          ><input
-            class="toggle toggle-xs"
-            type="checkbox"
-            bind:checked={$resetHotkey.modifiers.shift}
-          /></td
-        >
-        <td
-          ><input
-            class="toggle toggle-xs"
-            type="checkbox"
-            bind:checked={$resetHotkey.modifiers.alt}
-          /></td
-        >
-      </tr>
-      <tr>
-        <td>Timecode</td>
-        <td>
-          <input
-            class="input input-xs w-16"
-            type="text"
-            bind:value={$timecodeHotkey.key}
-          />
-        </td>
-        <td></td>
-        <td
-          ><input
-            class="toggle toggle-xs"
-            type="checkbox"
-            bind:checked={$timecodeHotkey.modifiers.control}
-          /></td
-        >
-        <td
-          ><input
-            class="toggle toggle-xs"
-            type="checkbox"
-            bind:checked={$timecodeHotkey.modifiers.shift}
-          /></td
-        >
-        <td
-          ><input
-            class="toggle toggle-xs"
-            type="checkbox"
-            bind:checked={$timecodeHotkey.modifiers.alt}
-          /></td
-        >
-      </tr>
+      {@render row("submit", "Submit", $submitHotkey, (v) =>
+        submitHotkey.set(v)
+      )}
+      {@render row("reset", "Reset", $resetHotkey, (v) => resetHotkey.set(v))}
+      {@render row("timecode", "Timecode", $timecodeHotkey, (v) =>
+        timecodeHotkey.set(v)
+      )}
       {#each $hotkeys as hotkey, i}
-        <tr>
-          <td>Hotkey {i + 1}</td>
-          <td>
-            <input
-              class="input input-xs w-16"
-              type="text"
-              bind:value={hotkey.key}
-            />
-          </td>
-          <td></td>
-          <td
-            ><input
-              class="toggle toggle-xs"
-              type="checkbox"
-              bind:checked={hotkey.modifiers.control}
-            /></td
-          >
-          <td
-            ><input
-              class="toggle toggle-xs"
-              type="checkbox"
-              bind:checked={hotkey.modifiers.shift}
-            /></td
-          >
-          <td
-            ><input
-              class="toggle toggle-xs"
-              type="checkbox"
-              bind:checked={hotkey.modifiers.alt}
-            /></td
-          >
-        </tr>
+        {@render row(`h${i}`, `Hotkey ${i + 1}`, hotkey, (v) =>
+          hotkeys.update((a) => a.map((x, j) => (j === i ? v : x)))
+        )}
       {/each}
       {#each $personalHotkeys as hotkey, i}
-        <tr>
-          <td>Personal Hotkey {i + 1}</td>
-          <td>
-            <input
-              class="input input-xs w-16"
-              type="text"
-              bind:value={hotkey.key}
-            />
-          </td>
-          <td>
-            <input
-              class="input input-xs w-16"
-              type="text"
-              bind:value={hotkey.text}
-            />
-          </td>
-          <td
-            ><input
-              class="toggle toggle-xs"
-              type="checkbox"
-              bind:checked={hotkey.modifiers.control}
-            /></td
-          >
-          <td
-            ><input
-              class="toggle toggle-xs"
-              type="checkbox"
-              bind:checked={hotkey.modifiers.shift}
-            /></td
-          >
-          <td
-            ><input
-              class="toggle toggle-xs"
-              type="checkbox"
-              bind:checked={hotkey.modifiers.alt}
-            /></td
-          >
-        </tr>
+        {@render row(
+          `p${i}`,
+          `Personal Hotkey ${i + 1}`,
+          hotkey,
+          (v) => personalHotkeys.update((a) => a.map((x, j) => (j === i ? v : x))),
+          true
+        )}
       {/each}
       <tr
         ><td colspan="2" class="text-center"
-          >Save or refresh to update hotkeys</td
+          >Click a key to rebind · Esc cancels · Save or refresh to update
+          hotkeys</td
         >
         <td
           ><button

--- a/src/lib/components/menu/HotkeysSettings.svelte
+++ b/src/lib/components/menu/HotkeysSettings.svelte
@@ -63,21 +63,25 @@
 </script>
 
 {#snippet row(id, label, hotkey, set, withText = false)}
-  <tr
-    class={conflicts.has(sig(hotkey)) ? "bg-error/20" : ""}
-    title={conflicts.has(sig(hotkey))
-      ? "Same combination as another hotkey"
-      : ""}
-  >
+  <tr class={conflicts.has(sig(hotkey)) ? "bg-error/20" : ""}>
     <td>{label}</td>
     <td>
-      <button
-        class="btn btn-xs w-32 font-mono"
-        class:btn-primary={armed?.id === id}
-        onclick={() => (armed = { id, current: hotkey, set })}
+      <span
+        class="tooltip tooltip-right"
+        data-tip={armed?.id === id
+          ? "Press the key combination you want · Esc to cancel"
+          : conflicts.has(sig(hotkey))
+            ? "Same combination as another hotkey · click to rebind"
+            : "Click, then press the key you want"}
       >
-        {armed?.id === id ? "Press key…" : display(hotkey)}
-      </button>
+        <button
+          class="btn btn-xs w-32 font-mono"
+          class:btn-primary={armed?.id === id}
+          onclick={() => (armed = { id, current: hotkey, set })}
+        >
+          {armed?.id === id ? "Press key…" : display(hotkey)}
+        </button>
+      </span>
     </td>
     <td>
       {#if withText}
@@ -89,23 +93,6 @@
         />
       {/if}
     </td>
-    {#each ["control", "shift", "alt"] as modifier}
-      <td>
-        <input
-          class="toggle toggle-xs"
-          type="checkbox"
-          checked={hotkey.modifiers[modifier]}
-          onchange={(e) =>
-            set({
-              ...hotkey,
-              modifiers: {
-                ...hotkey.modifiers,
-                [modifier]: e.currentTarget.checked,
-              },
-            })}
-        />
-      </td>
-    {/each}
   </tr>
 {/snippet}
 
@@ -114,11 +101,8 @@
     <thead>
       <tr>
         <th>type</th>
-        <th>Button</th>
+        <th>Keybind</th>
         <th>opt</th>
-        <th>Control</th>
-        <th>Shift</th>
-        <th>Alt</th>
       </tr>
     </thead>
     <tbody>
@@ -145,17 +129,8 @@
       {/each}
       <tr
         ><td colspan="2" class="text-center"
-          >Click a key to rebind · Esc cancels · Save or refresh to update
-          hotkeys</td
+          >Click a key to rebind · Esc cancels · changes apply immediately</td
         >
-        <td
-          ><button
-            class="btn btn-xs"
-            onclick={() => {
-              window.location.reload();
-            }}>Save</button
-          >
-        </td>
         <td
           ><button
             class="btn btn-xs"

--- a/src/lib/components/menu/HotkeysSettings.svelte
+++ b/src/lib/components/menu/HotkeysSettings.svelte
@@ -99,11 +99,11 @@
 {/snippet}
 
 <div class="flex flex-col gap-1">
-  <table class="table table-xs table-zebra w-full">
+  <table class="table table-xs table-zebra table-fixed w-full">
     <thead>
       <tr>
-        <th>type</th>
-        <th>Keybind</th>
+        <th class="w-1/3">type</th>
+        <th class="w-2/3">Keybind</th>
       </tr>
     </thead>
     <tbody>
@@ -128,28 +128,30 @@
           true
         )}
       {/each}
-      <tr
-        ><td class="text-center"
-          >Click a key to rebind · Esc cancels · changes apply immediately</td
-        >
-        <td
-          ><button
-            class="btn btn-xs"
-            onclick={() => {
-              hotkeys.set(structuredClone(defaults.hotkeys));
-              submitHotkey.set(structuredClone(defaults.submitHotkey));
-              resetHotkey.set(structuredClone(defaults.resetHotkey));
-              timecodeHotkey.set(structuredClone(defaults.timecodeHotkey));
-              // keybinds go back to default, the user's typed text stays
-              personalHotkeys.update((current) =>
-                defaults.personalHotkeys.map((d, i) => ({
-                  ...structuredClone(d),
-                  text: current[i]?.text ?? "",
-                }))
-              );
-            }}>Reset hotkeys</button
-          ></td
-        >
+      <tr>
+        <td colspan="2">
+          <div class="flex items-center justify-between gap-2">
+            <span
+              >Click a key to rebind · Esc cancels · changes apply immediately</span
+            >
+            <button
+              class="btn btn-xs shrink-0"
+              onclick={() => {
+                hotkeys.set(structuredClone(defaults.hotkeys));
+                submitHotkey.set(structuredClone(defaults.submitHotkey));
+                resetHotkey.set(structuredClone(defaults.resetHotkey));
+                timecodeHotkey.set(structuredClone(defaults.timecodeHotkey));
+                // keybinds go back to default, the user's typed text stays
+                personalHotkeys.update((current) =>
+                  defaults.personalHotkeys.map((d, i) => ({
+                    ...structuredClone(d),
+                    text: current[i]?.text ?? "",
+                  }))
+                );
+              }}>Reset hotkeys</button
+            >
+          </div>
+        </td>
       </tr>
     </tbody>
   </table>

--- a/src/lib/components/menu/HotkeysSettings.svelte
+++ b/src/lib/components/menu/HotkeysSettings.svelte
@@ -74,7 +74,7 @@
             ? "Press the key combination you want · Esc to cancel"
             : conflicts.has(sig(hotkey))
               ? "Same combination as another hotkey · click to rebind"
-              : "Click, then press the key you want"}
+              : "Click, and press the key combination you want"}
         >
           <button
             class="btn btn-xs w-32 font-mono"

--- a/src/lib/components/menu/HotkeysSettings.svelte
+++ b/src/lib/components/menu/HotkeysSettings.svelte
@@ -7,6 +7,7 @@
     personalHotkeys,
     defaults,
   } from "$lib/stores/hotkeysStore.js";
+  import { display, keyFromEvent } from "$lib/components/hotkeys/shortcut.js";
 
   // { id, current, set } of the row waiting for a keypress, or null
   let armed = $state(null);
@@ -15,12 +16,6 @@
 
   const sig = (h) =>
     `${h.modifiers.control}${h.modifiers.shift}${h.modifiers.alt}:${h.key}`;
-
-  const display = (h) =>
-    (h.modifiers.control ? "CTL + " : "") +
-    (h.modifiers.shift ? "SHIFT + " : "") +
-    (h.modifiers.alt ? "ALT + " : "") +
-    h.key;
 
   let allRows = $derived([
     $submitHotkey,
@@ -49,7 +44,7 @@
       if (MODIFIER_KEYS.includes(e.key)) return;
       armed.set({
         ...armed.current,
-        key: e.key,
+        key: keyFromEvent(e),
         modifiers: {
           control: e.ctrlKey || e.metaKey,
           shift: e.shiftKey,

--- a/src/lib/stores/hotkeysStore.js
+++ b/src/lib/stores/hotkeysStore.js
@@ -21,9 +21,13 @@ export const defaults = {
     ...h,
     text: "",
   })),
-  submitHotkey: { key: "Enter", modifiers: modifiers({ shift: true }) },
-  resetHotkey: { key: "R", modifiers: modifiers({ shift: true }) },
-  timecodeHotkey: { key: "T", modifiers: modifiers({ shift: true }) },
+  // Alt on all three: these fire while the logger textarea has focus, so they
+  // must not be things you can type, and Alt avoids the browser's Ctrl+T /
+  // Ctrl+R. macOS rewrites Alt+letter to "®", "†", … — the matcher falls back
+  // to the physical key for that.
+  submitHotkey: { key: "Enter", modifiers: modifiers({ alt: true }) },
+  resetHotkey: { key: "r", modifiers: modifiers({ alt: true }) },
+  timecodeHotkey: { key: "t", modifiers: modifiers({ alt: true }) },
 };
 
 // First param is the local storage key, second is the initial value.

--- a/src/lib/stores/hotkeysStore.js
+++ b/src/lib/stores/hotkeysStore.js
@@ -1,96 +1,40 @@
 import { persisted } from "svelte-persisted-store";
 
-// First param `preferences` is the local storage key.
-// Second param is the initial value.
-export const hotkeys = persisted("hotkeys", [
-  {
-    key: "F1",
-    modifiers: { control: false, shift: false, alt: true },
-  },
-  {
-    key: "F2",
-    modifiers: { control: false, shift: false, alt: true },
-  },
-  {
-    key: "F3",
-    modifiers: { control: false, shift: false, alt: true },
-  },
-  {
-    key: "F4",
-    modifiers: { control: false, shift: false, alt: true },
-  },
-  {
-    key: "F5",
-    modifiers: { control: false, shift: false, alt: true },
-  },
-  {
-    key: "F6",
-    modifiers: { control: false, shift: false, alt: true },
-  },
-  {
-    key: "F7",
-    modifiers: { control: false, shift: false, alt: true },
-  },
-  {
-    key: "F8",
-    modifiers: { control: false, shift: false, alt: true },
-  },
-]);
-
-export const personalHotkeys = persisted("personalHotkeys", [
-  {
-    key: "F1",
-    modifiers: { control: false, shift: false, alt: false },
-    text: "",
-  },
-  {
-    key: "F2",
-    modifiers: { control: false, shift: false, alt: false },
-    text: "",
-  },
-  {
-    key: "F3",
-    modifiers: { control: false, shift: false, alt: false },
-    text: "",
-  },
-  {
-    key: "F4",
-    modifiers: { control: false, shift: false, alt: false },
-    text: "",
-  },
-  {
-    key: "F5",
-    modifiers: { control: false, shift: false, alt: false },
-    text: "",
-  },
-  {
-    key: "F6",
-    modifiers: { control: false, shift: false, alt: false },
-    text: "",
-  },
-  {
-    key: "F7",
-    modifiers: { control: false, shift: false, alt: false },
-    text: "",
-  },
-  {
-    key: "F8",
-    modifiers: { control: false, shift: false, alt: false },
-    text: "",
-  },
-]);
-
-export const submitHotkey = persisted("submitHotkey", {
-  key: "F1",
-  modifiers: { control: false, shift: true, alt: false },
+const modifiers = (m = {}) => ({
+  control: false,
+  shift: false,
+  alt: false,
+  ...m,
 });
 
-export const resetHotkey = persisted("resetHotkey", {
-  key: "F2",
-  modifiers: { control: false, shift: true, alt: false },
-});
+const functionKeys = (m) =>
+  Array.from({ length: 8 }, (_, i) => ({
+    key: `F${i + 1}`,
+    modifiers: modifiers(m),
+  }));
 
-export const timecodeHotkey = persisted("timecodeHotkey", {
-  key: "F3",
-  modifiers: { control: false, shift: true, alt: false },
-});
+// Single source of truth: the stores seed from this and the settings modal's
+// "Reset hotkeys" button restores from it.
+export const defaults = {
+  hotkeys: functionKeys(),
+  personalHotkeys: functionKeys({ shift: true }).map((h) => ({
+    ...h,
+    text: "",
+  })),
+  submitHotkey: { key: "Enter", modifiers: modifiers({ shift: true }) },
+  resetHotkey: { key: "R", modifiers: modifiers({ shift: true }) },
+  timecodeHotkey: { key: "T", modifiers: modifiers({ shift: true }) },
+};
+
+// First param is the local storage key, second is the initial value.
+export const hotkeys = persisted("hotkeys", defaults.hotkeys);
+export const personalHotkeys = persisted(
+  "personalHotkeys",
+  defaults.personalHotkeys
+);
+export const submitHotkey = persisted("submitHotkey", defaults.submitHotkey);
+export const resetHotkey = persisted("resetHotkey", defaults.resetHotkey);
+export const timecodeHotkey = persisted(
+  "timecodeHotkey",
+  defaults.timecodeHotkey
+);

--- a/src/routes/logger/+page.svelte
+++ b/src/routes/logger/+page.svelte
@@ -1,7 +1,7 @@
 <script>
   import { socket } from "$lib/socket.js";
 
-  import { shortcut } from "$lib/components/hotkeys/shortcut.js";
+  import { shortcut, display } from "$lib/components/hotkeys/shortcut.js";
   import { tcOffsets } from "$lib/stores/tcOffsetStore.js";
   import { timecodeSource } from "$lib/stores/timecodeSourceStore.js";
   import {
@@ -227,14 +227,7 @@
       </div>
       <div
         class="text-2xl font-bold text-center select-none xl:text-3xl tooltip lg:tooltip-left"
-        data-tip="In-point for log TC click or {$timecodeHotkey.modifiers
-          .control
-          ? 'CTL + '
-          : ''}{$timecodeHotkey.modifiers.shift
-          ? 'SHIFT + '
-          : ''}{$timecodeHotkey.modifiers.alt
-          ? 'ALT + '
-          : ''}{$timecodeHotkey.key} to SET"
+        data-tip="In-point for log TC click or {display($timecodeHotkey)} to SET"
       >
         <div
           use:shortcut={{
@@ -270,12 +263,7 @@
               ></span>
             {:else}
               <div>Submit</div>
-              <div class="text-xs">
-                {$submitHotkey.modifiers.control ? "CTL + " : ""}
-                {$submitHotkey.modifiers.shift ? "SHIFT + " : ""}
-                {$submitHotkey.modifiers.alt ? "ALT + " : ""}
-                {$submitHotkey.key}
-              </div>
+              <div class="text-xs">{display($submitHotkey)}</div>
             {/if}
           </div>
         </button>
@@ -296,12 +284,7 @@
         >
           <div class="flex flex-col">
             <div>Reset</div>
-            <div class="text-xs">
-              {$resetHotkey.modifiers.control ? "CTL + " : ""}
-              {$resetHotkey.modifiers.shift ? "SHIFT + " : ""}
-              {$resetHotkey.modifiers.alt ? "ALT + " : ""}
-              {$resetHotkey.key}
-            </div>
+            <div class="text-xs">{display($resetHotkey)}</div>
           </div></button
         >
       </div>

--- a/src/routes/postlogger/+page.svelte
+++ b/src/routes/postlogger/+page.svelte
@@ -6,7 +6,7 @@
 
   import { socket } from "$lib/socket.js";
   import { submitHotkey, resetHotkey } from "$lib/stores/hotkeysStore.js";
-  import { shortcut } from "$lib/components/hotkeys/shortcut.js";
+  import { shortcut, display } from "$lib/components/hotkeys/shortcut.js";
 
   import Hotkeys from "$lib/components/hotkeys/Hotkeys.svelte";
   import Icon from "@iconify/svelte";
@@ -210,12 +210,7 @@
                 ></span>
               {:else}
                 <div>Submit</div>
-                <div class="text-xs">
-                  {$submitHotkey.modifiers.control ? "CTL + " : ""}
-                  {$submitHotkey.modifiers.shift ? "SHIFT + " : ""}
-                  {$submitHotkey.modifiers.alt ? "ALT + " : ""}
-                  {$submitHotkey.key}
-                </div>
+                <div class="text-xs">{display($submitHotkey)}</div>
               {/if}
             </div>
           </button>
@@ -233,12 +228,7 @@
           >
             <div class="flex flex-col">
               <div>Reset</div>
-              <div class="text-xs">
-                {$resetHotkey.modifiers.control ? "CTL + " : ""}
-                {$resetHotkey.modifiers.shift ? "SHIFT + " : ""}
-                {$resetHotkey.modifiers.alt ? "ALT + " : ""}
-                {$resetHotkey.key}
-              </div>
+              <div class="text-xs">{display($resetHotkey)}</div>
             </div></button
           >
         </div>


### PR DESCRIPTION
## Why

Setting a hotkey meant **typing the key name** into a text box (`F1`, `Enter`, `ArrowUp`…) and then hand-flipping three modifier toggles. Nothing told the user which exact `event.key` string the matcher expects, so a wrong guess produced a binding that silently never fired.

Now: click the keybind button, press the combination you want, done.

## What changed

**Press-to-bind capture** — the key cell is a button. Clicking arms it (`Press key…`), and the next keypress records the key *and* all three modifiers together. Esc cancels. Modifier-only presses are ignored so combinations can be held.

The capture listener runs in the **capture phase with `stopPropagation()`**, because `shortcut.js` listens on `window` in the bubble phase and is still live while the settings modal is open. Without this, binding Shift+Enter would fire the app's own Submit mid-capture.

`control` is stored as `ctrlKey || metaKey`, matching `shortcut.js` exactly.

The key itself is stored as the **physical key**, not `event.key`. `event.key` is the character the keypress *types*, so Shift+1 arrives as `"!"` and — on macOS — Alt+R arrives as `"®"`, producing a binding whose own label no longer names the key you pressed. `keyFromEvent` reads `event.code` for letters and digits (`Digit1` → `"1"`, `KeyR` → `"r"`) and falls back to `event.key` for everything else, so F-keys, Enter and Space are unaffected. The matcher accepts either form, which keeps bindings saved before this change working.

**Fixed the stale-params bug in `shortcut.js`** — `update` was `setHandler`, which takes no arguments and rebuilt the handler around the *original* `params` closure, so a rebound hotkey never took effect until a full page reload. `params` is now read at event time and `update` just swaps the reference. All call sites pass reactive store expressions, so changes apply live. The Save button (which only did `window.location.reload()`) and its "Save or refresh to update hotkeys" hint are gone, since they were now lying.

**New defaults**

| What | Binding |
|---|---|
| Marker hotkeys 1–8 | `F1` … `F8` |
| Personal hotkeys 1–8 | `Shift+F1` … `Shift+F8` |
| Submit | `Alt+Enter` |
| Reset | `Alt+R` |
| Timecode IN | `Alt+T` |

Alt on the three named bindings is deliberate. `shortcut.js` listens on `window` with no target guard, so a binding that is plain typing fires while the logger textarea has focus — Shift+R, an earlier candidate, is just a capital R, and it would call `loggerInput.set("")` and wipe the log being written. Alt combinations are not typeable, and unlike Ctrl they do not collide with the browser's own `Ctrl+T` / `Ctrl+R`.

The store and the "Reset hotkeys" button each carried their own hardcoded copy of the defaults, and they had already drifted: the button wrote `alt: false` where the store seeded `alt: true`, and it never reset the personal hotkeys at all. There is now a single exported `defaults` that both seed and restore from. Reset covers personal hotkeys too, but keeps the user's typed text.

**UI cleanup**
- Control/Shift/Alt toggle columns removed — capture sets them and the button already renders the full combination.
- The `opt` column was empty on 11 of 19 rows; the personal-hotkey text input is now inline beside its keybind button, with `Input text` as the placeholder.
- `Button` column renamed to `Keybind`; table is `table-fixed` at 1/3 / 2/3 so the bind buttons line up on one left edge.
- DaisyUI tooltip on the keybind button, which also carries the duplicate-binding explanation.
- Duplicate bindings highlight the conflicting rows. Non-blocking.

**Label rendering** — the `CTL + / SHIFT + / ALT + ` ternary chain was inlined at seven call sites (settings, `Hotkeys`, `PersonalHotkeys`, `/logger` ×3, `/postlogger` ×2), all rendering `hotkey.key` raw. That is now one exported `display()`, which is also what uppercases single characters — without it the physical keys, stored lowercase, would render as `ALT + r`. It renders `" "` as `Space` too, which previously showed as a blank button.

Row markup was repeated five times; it is now one snippet. Toggles/inputs moved from `bind:` to explicit setter callbacks, because `svelte-persisted-store` only writes to localStorage on `.set()`/`.update()` — mutating a bound object would not have persisted.

## Notes for the reviewer

- **Existing users keep their old bindings.** `svelte-persisted-store` only uses the initial value when localStorage is empty, so the new defaults reach new users and fresh browsers only; everyone else needs to press "Reset hotkeys". Since the old defaults were all F-keys, that is the safe outcome rather than a gap — no migration here.
- **One stale-data case is not migrated.** A binding captured by an earlier build of this branch may hold `"!"` or `"®"`. It still displays as typed and no longer matches its physical key. "Reset hotkeys" clears it.
- `shortcut.js` still listens on `window` with no `event.target` guard. The defaults above are all untypeable, so they are safe, but a user who rebinds Reset to a bare letter can still wipe the logger textarea by typing. Worth a follow-up.
- macOS swallows `Cmd+W` / `Cmd+Q` / `Cmd+Tab` before the page sees keydown, so those cannot be bound. `F5` / `F11` are preventable in Chrome and bind fine.

## Testing

`svelte-check` reports 0 errors. `vitest run` is 22/22.

New `src/lib/components/hotkeys/shortcut.test.js` (9 tests) covers exact matching, meta-as-control, **rebinding via `update`** (the bug fixed here), the `node.click()` fallback, destroy, `keyFromEvent` in both directions, and matching a physical-key binding through the typed character (`Shift+1` arriving as `"!"`, macOS `Alt+R` arriving as `"®"`). It stubs `window` by hand rather than adding jsdom, since this repo's vitest runs in the node environment with no DOM.

Not verified in a browser — the settings modal is behind login. Worth a manual pass on: arming a row and pressing a combination, Esc cancelling, the conflict highlight, that `Shift+1` labels itself `SHIFT + 1`, and that Alt+Enter / Alt+R / Alt+T work from inside the logger textarea on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KctbMzgxbeHn5GRD6Cjhjw
