### PR TITLE
fix: log users out when their session dies instead of failing silently

### DIFF
--- a/src/hooks.server.js
+++ b/src/hooks.server.js
@@ -1,6 +1,6 @@
 import {sequence} from "@sveltejs/kit/hooks";
 import * as Sentry from "@sentry/sveltekit";
-import { redirect } from "@sveltejs/kit";
+import { json, redirect } from "@sveltejs/kit";
 import jwt from "jsonwebtoken";
 
 import { env } from "$env/dynamic/private";
@@ -16,6 +16,26 @@ Sentry.init({
 
 export const handleError = Sentry.handleErrorWithSentry();
 
+const SESSION_EXPIRED = { message: "Session expired. Please sign in again." };
+
+// API calls need a real 401 so the client can react. Page requests get the redirect.
+const endSession = (event) => {
+  event.cookies.delete("AuthorizationToken", { path: "/" });
+
+  if (event.url.pathname.startsWith("/api")) {
+    const response = json(SESSION_EXPIRED, { status: 401 });
+    // SvelteKit only serializes cookies onto responses it resolves, so a
+    // Response returned straight out of `handle` needs the header attached here.
+    response.headers.append(
+      "set-cookie",
+      event.cookies.serialize("AuthorizationToken", "", { path: "/", maxAge: 0 })
+    );
+    return response;
+  }
+
+  throw redirect(303, "/");
+};
+
 export const handle = sequence(Sentry.sentryHandle(), async function _handle({ event, resolve }) {
   const requestedPath = event.url.pathname;
   const { headers } = event.request;
@@ -27,55 +47,59 @@ export const handle = sequence(Sentry.sentryHandle(), async function _handle({ e
 
     const token = authCookie.split(" ")[1];
 
+    let jwtUser;
+
     try {
-      const jwtUser = jwt.verify(token, env.PRIVATE_JWT_ACCESS_SECRET);
+      jwtUser = jwt.verify(token, env.PRIVATE_JWT_ACCESS_SECRET);
+    } catch (error) {
+      // Expired or tampered token
+      console.error(error);
+      return endSession(event);
+    }
 
-      if (typeof jwtUser === "string") {
-        throw new Error("Something went wrong");
-      }
+    if (typeof jwtUser === "string") {
+      return endSession(event);
+    }
 
-      const user = await db.user.findUnique({
-        where: {
-          id: jwtUser.id,
-        },
-        include: {
-          assignedProjects: {
-            select: {
-              id: true,
-              createdAt: true,
-              name: true,
-              contact: true,
-              projectDays: true,
-              markerColors: true,
-            },
+    // Deliberately outside the try: a DB failure must surface as a 500,
+    // not silently delete everyone's session cookie.
+    const user = await db.user.findUnique({
+      where: {
+        id: jwtUser.id,
+      },
+      include: {
+        assignedProjects: {
+          select: {
+            id: true,
+            createdAt: true,
+            name: true,
+            contact: true,
+            projectDays: true,
+            markerColors: true,
           },
         },
-      });
+      },
+    });
 
-      if (!user) {
-        throw new Error("User not found");
-      }
-
-      const sessionUser = {
-        id: user.id,
-        email: user.email,
-        firstName: user.firstName,
-        lastName: user.lastName,
-        fullName: user.fullName,
-        isAdmin: user.isAdmin,
-        projectController: user.projectController,
-        assignedProjects: user.assignedProjects ? user?.assignedProjects : null,
-        projectIds: user.projectIds,
-        selectedProjectId: user.selectedProjectId,
-      };
-
-      event.locals.user = sessionUser;
-    } catch (error) {
-      // JWT error
-      event.cookies.delete("AuthorizationToken", { path: "/" });
-      console.error(error);
-      throw redirect(303, "/");
+    if (!user) {
+      // Valid token, but the user is gone
+      return endSession(event);
     }
+
+    const sessionUser = {
+      id: user.id,
+      email: user.email,
+      firstName: user.firstName,
+      lastName: user.lastName,
+      fullName: user.fullName,
+      isAdmin: user.isAdmin,
+      projectController: user.projectController,
+      assignedProjects: user.assignedProjects ? user?.assignedProjects : null,
+      projectIds: user.projectIds,
+      selectedProjectId: user.selectedProjectId,
+    };
+
+    event.locals.user = sessionUser;
   } else {
     event.locals.user = null;
   }
@@ -106,7 +130,7 @@ export const handle = sequence(Sentry.sentryHandle(), async function _handle({ e
 
   if (requestedPath.startsWith("/api")) {
     if (!event.locals.user) {
-      return new Response("error");
+      return endSession(event);
     }
   }
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,7 +1,9 @@
 <script>
+  import { onMount } from "svelte";
   import { goto } from "$app/navigation";
   import Alerts from "$lib/components/alerts/Alerts.svelte";
   import SettingsModal from "$lib/components/menu/SettingsModal.svelte";
+  import { AlertsStore } from "$lib/stores/alertsStore.js";
   import "../app.css";
   import Icon from "@iconify/svelte";
 
@@ -13,8 +15,30 @@
 
   const gotoLink = (e) => {
     sideBarOpen = false;
-    goto(e.target.href);
+    goto(e.currentTarget.href);
   };
+
+  // The app is a client-rendered SPA, so a session that dies while the user sits
+  // on /logger is only ever visible in an API response. Catch it in one place
+  // instead of at all 14 fetch call sites.
+  onMount(() => {
+    const originalFetch = window.fetch;
+
+    window.fetch = async (...args) => {
+      const res = await originalFetch(...args);
+
+      if (res.status === 401 && !location.pathname.startsWith("/login")) {
+        AlertsStore.addAlert("Session expired. Please sign in again.", "warning");
+        goto("/login", { invalidateAll: true });
+      }
+
+      return res;
+    };
+
+    return () => {
+      window.fetch = originalFetch;
+    };
+  });
 </script>
 
 <Alerts />

--- a/src/routes/logger/+page.svelte
+++ b/src/routes/logger/+page.svelte
@@ -130,10 +130,21 @@
       frames: parseInt(inTimecode.split(":")[3]),
     };
 
-    const res = await fetch("/api/log", {
-      method: "POST",
-      body: JSON.stringify({ ...input, body: $loggerInput }),
-    });
+    let res;
+
+    try {
+      res = await fetch("/api/log", {
+        method: "POST",
+        body: JSON.stringify({ ...input, body: $loggerInput }),
+      });
+    } catch {
+      AlertsStore.addAlert(
+        "Could not reach the server. The log was not saved.",
+        "warning",
+      );
+      submittingLog = false;
+      return;
+    }
     if (!res.ok) {
       const json = await res.json();
       AlertsStore.addAlert(json.message, "warning");

--- a/src/routes/postlogger/+page.svelte
+++ b/src/routes/postlogger/+page.svelte
@@ -44,10 +44,21 @@
       day: parseInt(dateInput.split("-")[2]),
     };
 
-    const res = await fetch("/api/log", {
-      method: "POST",
-      body: JSON.stringify({ ...input, body: $postLoggerInput }),
-    });
+    let res;
+
+    try {
+      res = await fetch("/api/log", {
+        method: "POST",
+        body: JSON.stringify({ ...input, body: $postLoggerInput }),
+      });
+    } catch {
+      AlertsStore.addAlert(
+        "Could not reach the server. The log was not saved.",
+        "warning",
+      );
+      submittingLog = false;
+      return;
+    }
 
     if (!res.ok) {
       const json = await res.json();


### PR DESCRIPTION
## The bug

When a user's session ended they were never logged out. They stayed on `/logger`, kept submitting logs, and every submit *appeared* to succeed — draft cleared, spinner stopped, no error — while nothing reached the database.

`src/hooks.server.js` returned `new Response("error")` for unauthenticated `/api/*` requests, which is **HTTP 200**:

```js
if (requestedPath.startsWith("/api")) {
  if (!event.locals.user) {
    return new Response("error");   // status 200
  }
}
```

`logger/+page.svelte` guards with `if (!res.ok)`. 200 is ok, so it took the **success** branch: emitted the socket event, ran `loggerInput.set("")` wiping the typed draft, and cleared the spinner. Same in `postlogger`. The other 12 client fetch sites don't check `res.ok` at all.

Page navigations did log out correctly, but `/logger` is a client-rendered SPA screen (`+layout.js` is `export const ssr = false`), so a user who sits there and logs never re-checks their session.

## Which path production was actually hitting

The supplied production log contains **no `TokenExpiredError` or `JsonWebTokenError`**, even though the JWT catch block does `console.error(error)`. Both strings were confirmed to print when those branches fire, so their absence means sessions were not dying via `jwt.verify` — the browser was simply no longer sending the cookie.

That matches the code: the JWT is signed `expiresIn: "30d"` and the cookie is set `maxAge: 60 * 60 * 24 * 30`, both anchored at login and **never refreshed**. Users hit a hard 30-day cliff mid-session and land in the missing-cookie branch — straight into the 200 above.

Session length is unchanged here; this PR makes the cliff visible rather than moving it.

## Changes

**`src/hooks.server.js`** — both dead-session paths now go through one `endSession` helper: a real **401** with the session cookie cleared for `/api` requests, the existing redirect for page requests. SvelteKit only serializes cookies onto responses it resolves, so the `Set-Cookie` header is attached explicitly on the early return.

The JWT catch also swallowed everything, including Prisma failures — a DB blip deleted the auth cookie for every active user. Only `jwt.verify` is inside the `try` now; `findUnique` sits outside and surfaces as a 500 with the session intact.

**`src/routes/+layout.svelte`** — wraps `window.fetch` once and reacts to any 401 with an alert and a redirect to `/login`, instead of adding a check to each of the 14 fetch call sites. Reuses the existing `AlertsStore`.

**`logger` / `postlogger`** — a `catch` around the submit fetch, so a network failure no longer strands the textarea disabled behind a permanent spinner. The draft now survives a failed submit, since the `!res.ok` return happens before `loggerInput.set("")`.

Also fixes `gotoLink` using `e.target.href` instead of `e.currentTarget.href`, which sent users to `/undefined` when they clicked the `<span>` inside a nav link — visible in the log as `Not found: /undefined` followed by a burst of `/undefined/_app/immutable/*` 404s.

## Verification

Run against a live dev server over real HTTP:

| case | before | after |
|---|---|---|
| no cookie, `POST /api/log` | 200 `"error"` | **401** + JSON body + cookie cleared |
| malformed token | 200 | **401** + cookie cleared |
| genuinely expired JWT | 200 | **401** + cookie cleared |
| expired token, `GET /logger` | 303 → `/` | 303 → `/` (unchanged) |
| `/`, `/login` | 200 | 200 (unchanged) |
| **DB unreachable, valid token** | cookie deleted, user logged out | **500, session preserved** |
| valid token, user deleted from DB | 200 `"error"` | **401** + cookie cleared |
| **valid session**, `GET /api/log` | 200 | 200, session untouched |
| valid session, `GET /logger` + `/viewer` | 200 | 200 |
| non-admin, `GET /admin` | 303 → `/` | 303 → `/` (unchanged) |

The DB-unreachable row was not simulated — MongoDB Atlas was genuinely down from the test machine at the time, so it exercised the real path.

Every branch was then re-run against a reachable Atlas, including a real signed session for an existing user, confirming authenticated traffic is untouched and no spurious 401 or cookie clear occurs.

`npx vite build` clean, 13/13 tests pass.

## Separate issue found, not fixed here

`PRIVATE_JWT_ACCESS_SECRET` in `.env` is quoted and contains a `#`. dotenv (`npm run server`, production) keeps all 30 characters; Vite/SvelteKit dev truncates at the `#` to 24. **Dev and production therefore sign JWTs with different secrets.** Production is self-consistent so this is not the live bug, but any change to how `.env` is loaded would invalidate every active session at once. Removing or escaping the `#` fixes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HvaJUpjztbG3Mjb282nfbU

