### PR TITLE
fix: stop unguarded async fetches throwing unhandled rejections

### DIFF
--- a/src/routes/live/+page.svelte
+++ b/src/routes/live/+page.svelte
@@ -20,13 +20,21 @@
   socket.emit("joinProject", data.currentProject.id);
 
   socket.on("fetchNewData", async (projectId) => {
-    let now = dayjs();
-    if (projectId == user.selectedProjectId) {
+    if (projectId != user.selectedProjectId) return;
+
+    // socket.io never awaits this handler, so anything that throws here becomes
+    // an unhandled rejection. Keep the logs we already have and wait for the
+    // next event rather than tearing the list down.
+    try {
+      let now = dayjs();
       const res = await fetch(
         "/api/log?page=0&perPage=50&localDate=" + now.format("YYYY.MM.DD")
       );
+      if (!res.ok) return;
       const data = await res.json();
       logs = data.logs;
+    } catch {
+      // offline, reconnecting, or mid-deploy; the next fetchNewData refreshes
     }
   });
 

--- a/src/routes/logger/+page.svelte
+++ b/src/routes/logger/+page.svelte
@@ -87,14 +87,22 @@
   socket.emit("joinProject", data.currentProject.id);
 
   socket.on("fetchNewData", async (projectId) => {
-    if (projectId == user.selectedProjectId) {
+    if (projectId != user.selectedProjectId) return;
+
+    // socket.io never awaits this handler, so anything that throws here becomes
+    // an unhandled rejection. Keep the logs we already have and wait for the
+    // next event rather than tearing the list down.
+    try {
       const snapshot = getCurrentTimecodeSnapshot();
       const res = await fetch(
         "/api/log?page=0&perPage=10&localDate=" +
           toLocalDateString(snapshot.localDate),
       );
+      if (!res.ok) return;
       const data = await res.json();
       logs = data.logs;
+    } catch {
+      // offline, reconnecting, or mid-deploy; the next fetchNewData refreshes
     }
   });
 

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -9,6 +9,7 @@
   import dayjs from "dayjs";
 
   import SearchBadge from "$lib/components/viewer/SearchBadge.svelte";
+  import { AlertsStore } from "$lib/stores/alertsStore.js";
 
   let { data } = $props();
 
@@ -44,16 +45,25 @@
 
     goto(`?${$page.url.searchParams.toString()}`);
 
-    const res = await fetch(
-      `/api/log/search?query=${searchInput}&page=${currentPage}&perPage=${perPage}&filters=${filters.join(",")}&asc=${asc ? "asc" : "desc"}${dateSelectorOpen ? "&localDate=" + selectedDate : ""}`,
-    );
-    const data = await res.json();
+    try {
+      const res = await fetch(
+        `/api/log/search?query=${searchInput}&page=${currentPage}&perPage=${perPage}&filters=${filters.join(",")}&asc=${asc ? "asc" : "desc"}${dateSelectorOpen ? "&localDate=" + selectedDate : ""}`,
+      );
+      if (!res.ok) return;
+      const data = await res.json();
 
-    logs = data.logs;
-    pages = data.page;
-
-    loading = false;
-    firstSearchDone = true;
+      logs = data.logs;
+      pages = data.page;
+      firstSearchDone = true;
+    } catch {
+      AlertsStore.addAlert(
+        "Could not run the search. Check your connection and try again.",
+        "warning",
+      );
+    } finally {
+      // must always clear, or the search spins forever on a failed fetch
+      loading = false;
+    }
   };
 </script>
 

--- a/src/routes/viewer/+page.svelte
+++ b/src/routes/viewer/+page.svelte
@@ -7,6 +7,7 @@
   import dayjs from "dayjs";
 
   import SearchBadge from "$lib/components/viewer/SearchBadge.svelte";
+  import { AlertsStore } from "$lib/stores/alertsStore.js";
 
   let { data } = $props();
 
@@ -38,7 +39,9 @@
     $page.url.searchParams.set("selectedDate", selectedDate);
     $page.url.searchParams.set("filters", filters);
     goto(`?${$page.url.searchParams.toString()}`);
-    const res = await fetch(
+
+    try {
+      const res = await fetch(
       `/api/log?page=${currentPage}&perPage=${perPage}&localDate=${selectedDate}&filters=${filters.join(",")}&asc=${asc ? "asc" : "desc"}${
         showTimecodePicker
           ? `&afterTc=${inTimecode.hours
@@ -60,17 +63,25 @@
               .padStart(2, "0")}`
           : ""
       }`
-    );
-    const data = await res.json();
-    logs = data.logs;
-    pages = data.page;
+      );
+      if (!res.ok) return;
+      const data = await res.json();
+      logs = data.logs;
+      pages = data.page;
 
-    if (currentPage > pages.totalPages) {
-      currentPage = 0;
-      getNewData();
+      if (currentPage > pages.totalPages) {
+        currentPage = 0;
+        getNewData();
+      }
+    } catch {
+      AlertsStore.addAlert(
+        "Could not load logs. Check your connection and try again.",
+        "warning",
+      );
+    } finally {
+      // must always clear, or the viewer spins forever on a failed fetch
+      loading = false;
     }
-
-    loading = false;
   };
 
   let isOpen = $state(false);


### PR DESCRIPTION
Fixes WEBLOGGER-W
Fixes WEBLOGGER-11

Two bugs of the same class, found by working the `TypeError: Failed to fetch` issues in Sentry: an `async` function is invoked from a callback that never awaits it, so any failure inside escapes as an **unhandled promise rejection**. Both events confirm it — `mechanism: auto.browser.global_handlers.onunhandledrejection`, `handled: no`.

## 1. Socket refresh handlers — WEBLOGGER-W

6 events / 5 users over 17 days, still firing the day before this was written.

`logger/+page.svelte:89` registers an `async` handler with Socket.IO, which neither awaits nor catches the returned promise:

```js
socket.on("fetchNewData", async (projectId) => {
  if (projectId == user.selectedProjectId) {
    const res = await fetch("/api/log?page=0&perPage=10&localDate=" + ...);
    const data = await res.json();
    logs = data.logs;
  }
});
```

Triggers are ordinary: a network blip, a laptop waking from sleep, or the socket reconnecting mid-deploy and refetching before the server is serving again.

Not only noise — when the fetch threw, `logs = data.logs` never ran, so the list silently stopped refreshing: a user posts a log and never sees it appear. That is the read-side twin of the silent submit failure fixed in v1.4.0.

`live/+page.svelte:22` had the identical pattern and is fixed too, rather than only the path the issue named.

## 2. Viewer and search loading state — WEBLOGGER-11

`viewer/+page.svelte:41` `getNewData` sets `loading = true`, awaits a fetch, and clears `loading` **only on success**. It is called from click handlers without `await`.

So a failure did two things: raised an unhandled rejection, and stranded `loading` at true — the GO button in the timecode filter panel renders as a spinner forever, recoverable only by reloading the page.

`search/+page.svelte:41` has the identical shape and both failure modes; it simply had not been hit in the last 30 days.

## The change

Every affected handler now:
- guards the fetch, so a failure cannot escape as an unhandled rejection
- skips non-ok responses instead of parsing an error body into `logs`
- keeps already-rendered logs rather than tearing the list down
- clears `loading` in a `finally` (viewer/search), so the spinner can never be stranded

The socket handlers stay silent on failure — a background refresh is repaired by the next event. The user-initiated viewer/search actions raise a warning alert; `AlertsStore` was not previously imported in either file.

## Verification

No unit tests: these guards live inside `.svelte` components and the repo has no component-test infrastructure (the existing suite is plain-JS modules). Verified instead against a running dev server, forcing `/api/log` fetches to reject and driving the real triggers — firing genuine `newData` events from a separate Socket.IO client, and clicking the actual pagination and GO buttons.

| scenario | before | after |
|---|---|---|
| socket `fetchNewData` (2 fetches) | **4** unhandled rejections | **0** |
| viewer pagination click | **1** unhandled rejection, no feedback | **0**, warning alert |
| viewer GO with timecode panel open | button stuck as a spinner indefinitely | returns to `GO`, alert shown |
| rendered log rows | preserved | preserved |

`npx vite build` clean, 22/22 tests pass.

## Notes on the sibling issues

- **WEBLOGGER-H** shares the title but its frame is `logger:133`, the `submitLog` POST — already fixed in v1.4.0 and closed separately.
- **WEBLOGGER-S** and **WEBLOGGER-T** also share the title but have **no application frame**: they come through SvelteKit's link preloading and client `handle_error`, i.e. a user's network dropping during navigation. No code change here would prevent them, and they are deliberately untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HvaJUpjztbG3Mjb282nfbU
