### PR TITLE
fix: tag dev Sentry events as development, not production

### DIFF
--- a/src/hooks.client.js
+++ b/src/hooks.client.js
@@ -1,6 +1,6 @@
 import { handleErrorWithSentry, replayIntegration } from "@sentry/sveltekit";
 import * as Sentry from "@sentry/sveltekit";
-import { env } from "$env/dynamic/public";
+import { dev } from "$app/environment";
 
 Sentry.init({
   dsn: "https://6ff730d0e1c9e8e48ee1103159eb5434@o4509541128601600.ingest.de.sentry.io/4511008257278032",
@@ -24,7 +24,7 @@ Sentry.init({
   // Enable sending user PII (Personally Identifiable Information)
   // https://docs.sentry.io/platforms/javascript/guides/sveltekit/configuration/options/#sendDefaultPii
   sendDefaultPii: true,
-  environment: env.NODE_ENV || "production",
+  environment: dev ? "development" : "production",
 });
 
 // If you have a custom error handler, pass it to `handleErrorWithSentry`

--- a/src/hooks.server.js
+++ b/src/hooks.server.js
@@ -4,6 +4,7 @@ import { json, redirect } from "@sveltejs/kit";
 import jwt from "jsonwebtoken";
 
 import { env } from "$env/dynamic/private";
+import { dev } from "$app/environment";
 import { db } from "$lib/db.js";
 
 Sentry.init({
@@ -11,7 +12,7 @@ Sentry.init({
     tracesSampleRate: 1,
     enableLogs: true,
     sendDefaultPii: true,
-    environment: env.NODE_ENV || "production",
+    environment: dev ? "development" : "production",
 })
 
 export const handleError = Sentry.handleErrorWithSentry();


### PR DESCRIPTION
## Problem

Both Sentry inits set `environment: env.NODE_ENV || "production"`.

On the client, `env` comes from `$env/dynamic/public`, which only exposes `PUBLIC_`-prefixed variables. `NODE_ENV` is never in it, so the fallback always won — every localhost dev event landed in Sentry tagged `environment: production`.

## Fix

Use SvelteKit's `dev` flag from `$app/environment` in both `hooks.client.js` and `hooks.server.js`:

```js
environment: dev ? "development" : "production",
```

`dev` comes from build/dev mode, not an ambient variable, so it is correct on client and server regardless of how the process was started. The now-unused `$env/dynamic/public` import was dropped from the client hook; `hooks.server.js` still uses `env` for `PRIVATE_JWT_ACCESS_SECRET`.

## Evidence

Four Sentry issues had events with `url:*localhost*` and zero non-localhost events — all tagged `environment: production`: WEBLOGGER-13, WEBLOGGER-14, WEBLOGGER-15, WEBLOGGER-P. They have been resolved as dev noise.

Not included: a `SENTRY_ENVIRONMENT` variable for a staging tier — there is no staging deploy today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HvaJUpjztbG3Mjb282nfbU